### PR TITLE
feat: add new reject reason for payload too long

### DIFF
--- a/server-manager.proto
+++ b/server-manager.proto
@@ -176,6 +176,7 @@ enum CompletionStatus {
     MACHINE_HALTED = 3;
     CYCLE_LIMIT_EXCEEDED = 4;
     TIME_LIMIT_EXCEEDED = 5;
+    PAYLOAD_LENGTH_LIMIT_EXCEEDED = 6;
 }
 
 message AcceptedData {


### PR DESCRIPTION
This is needed to fix issue cartesi/server-manager#4.