### PR TITLE
feat: add init and entrypoint fields to machine ROM

### DIFF
--- a/cartesi-machine.proto
+++ b/cartesi-machine.proto
@@ -178,6 +178,8 @@ message ProcessorConfig {
 message DTBConfig {
     string bootargs = 1;
     string image_filename = 2;
+    string init = 3;
+    string entrypoint = 4;
 }
 
 message RAMConfig {


### PR DESCRIPTION
This is related to:
- https://github.com/cartesi/machine-emulator/pull/140